### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/test-server/data.go
+++ b/cmd/test-server/data.go
@@ -4,6 +4,30 @@ import (
 	"sync"
 )
 
+const (
+	roleWorkspaceAdminID    = "role_workspace_admin"
+	roleWorkspaceAdminName  = "Workspace Admin"
+	roleSourceAdminID       = "role_source_admin"
+	roleSourceAdminName     = "Source Admin"
+	roleSourceReadonlyID    = "role_source_readonly"
+	roleSourceReadonlyName  = "Source Read-only"
+	roleDestAdminID         = "role_destination_admin"
+	roleDestAdminName       = "Destination Admin"
+	roleDestReadonlyID      = "role_destination_readonly"
+	roleDestReadonlyName    = "Destination Read-only"
+	roleWarehouseAdminID    = "role_warehouse_admin"
+	roleWarehouseAdminName  = "Warehouse Admin"
+	workspace001ID          = "workspace_001"
+	user001ID               = "user_001"
+	user002ID               = "user_002"
+	user005ID               = "user_005"
+	user006ID               = "user_006"
+	source002ID             = "source_002"
+	warehouse001ID          = "warehouse_001"
+	source001ID             = "source_001"
+	resourceTypeSource      = "SOURCE"
+)
+
 // User represents a Segment IAM user.
 type User struct {
 	ID          string       `json:"id"`
@@ -128,34 +152,34 @@ func (ts *TestServer) initSampleData() {
 		Name:        "Workspace Owner",
 		Description: "Full control over the workspace including billing and team management",
 	}
-	ts.roles["role_workspace_admin"] = Role{
-		ID:          "role_workspace_admin",
-		Name:        "Workspace Admin",
+	ts.roles[roleWorkspaceAdminID] = Role{
+		ID:          roleWorkspaceAdminID,
+		Name:        roleWorkspaceAdminName,
 		Description: "Administrative access to workspace settings and resources",
 	}
-	ts.roles["role_source_admin"] = Role{
-		ID:          "role_source_admin",
-		Name:        "Source Admin",
+	ts.roles[roleSourceAdminID] = Role{
+		ID:          roleSourceAdminID,
+		Name:        roleSourceAdminName,
 		Description: "Full control over sources in the workspace",
 	}
-	ts.roles["role_source_readonly"] = Role{
-		ID:          "role_source_readonly",
-		Name:        "Source Read-only",
+	ts.roles[roleSourceReadonlyID] = Role{
+		ID:          roleSourceReadonlyID,
+		Name:        roleSourceReadonlyName,
 		Description: "Read-only access to sources",
 	}
-	ts.roles["role_destination_admin"] = Role{
-		ID:          "role_destination_admin",
-		Name:        "Destination Admin",
+	ts.roles[roleDestAdminID] = Role{
+		ID:          roleDestAdminID,
+		Name:        roleDestAdminName,
 		Description: "Full control over destinations in the workspace",
 	}
-	ts.roles["role_destination_readonly"] = Role{
-		ID:          "role_destination_readonly",
-		Name:        "Destination Read-only",
+	ts.roles[roleDestReadonlyID] = Role{
+		ID:          roleDestReadonlyID,
+		Name:        roleDestReadonlyName,
 		Description: "Read-only access to destinations",
 	}
-	ts.roles["role_warehouse_admin"] = Role{
-		ID:          "role_warehouse_admin",
-		Name:        "Warehouse Admin",
+	ts.roles[roleWarehouseAdminID] = Role{
+		ID:          roleWarehouseAdminID,
+		Name:        roleWarehouseAdminName,
 		Description: "Full control over warehouses in the workspace",
 	}
 	ts.roles["role_function_admin"] = Role{
@@ -165,24 +189,24 @@ func (ts *TestServer) initSampleData() {
 	}
 
 	// Workspace resource for permissions
-	wsResource := Resource{ID: "workspace_001", Type: "WORKSPACE"}
+	wsResource := Resource{ID: workspace001ID, Type: "WORKSPACE"}
 
 	// Sample users with various roles (all permissions must have Resources)
-	ts.users["user_001"] = User{
-		ID:    "user_001",
+	ts.users[user001ID] = User{
+		ID:    user001ID,
 		Name:  "Alice Johnson",
 		Email: "alice.johnson@example.com",
 		Permissions: []Permission{
 			{RoleID: "role_workspace_owner", RoleName: "Workspace Owner", Resources: []Resource{wsResource}},
 		},
 	}
-	ts.users["user_002"] = User{
-		ID:    "user_002",
+	ts.users[user002ID] = User{
+		ID:    user002ID,
 		Name:  "Bob Smith",
 		Email: "bob.smith@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_workspace_admin", RoleName: "Workspace Admin", Resources: []Resource{wsResource}},
-			{RoleID: "role_source_admin", RoleName: "Source Admin", Resources: []Resource{{ID: "source_001", Type: "SOURCE"}}},
+			{RoleID: roleWorkspaceAdminID, RoleName: roleWorkspaceAdminName, Resources: []Resource{wsResource}},
+			{RoleID: roleSourceAdminID, RoleName: roleSourceAdminName, Resources: []Resource{{ID: source001ID, Type: resourceTypeSource}}},
 		},
 	}
 	ts.users["user_003"] = User{
@@ -190,8 +214,8 @@ func (ts *TestServer) initSampleData() {
 		Name:  "Carol Williams",
 		Email: "carol.williams@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_source_readonly", RoleName: "Source Read-only", Resources: []Resource{{ID: "source_002", Type: "SOURCE"}}},
-			{RoleID: "role_destination_readonly", RoleName: "Destination Read-only", Resources: []Resource{wsResource}},
+			{RoleID: roleSourceReadonlyID, RoleName: roleSourceReadonlyName, Resources: []Resource{{ID: source002ID, Type: resourceTypeSource}}},
+			{RoleID: roleDestReadonlyID, RoleName: roleDestReadonlyName, Resources: []Resource{wsResource}},
 		},
 	}
 	ts.users["user_004"] = User{
@@ -199,24 +223,24 @@ func (ts *TestServer) initSampleData() {
 		Name:  "David Brown",
 		Email: "david.brown@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_destination_admin", RoleName: "Destination Admin", Resources: []Resource{wsResource}},
+			{RoleID: roleDestAdminID, RoleName: roleDestAdminName, Resources: []Resource{wsResource}},
 		},
 	}
-	ts.users["user_005"] = User{
-		ID:    "user_005",
+	ts.users[user005ID] = User{
+		ID:    user005ID,
 		Name:  "Eve Davis",
 		Email: "eve.davis@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_warehouse_admin", RoleName: "Warehouse Admin", Resources: []Resource{{ID: "warehouse_001", Type: "WAREHOUSE"}}},
+			{RoleID: roleWarehouseAdminID, RoleName: roleWarehouseAdminName, Resources: []Resource{{ID: warehouse001ID, Type: "WAREHOUSE"}}},
 			{RoleID: "role_function_admin", RoleName: "Function Admin", Resources: []Resource{{ID: "func_001", Type: "FUNCTION"}}},
 		},
 	}
-	ts.users["user_006"] = User{
-		ID:    "user_006",
+	ts.users[user006ID] = User{
+		ID:    user006ID,
 		Name:  "Frank Miller",
 		Email: "frank.miller@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_source_readonly", RoleName: "Source Read-only", Resources: []Resource{{ID: "source_003", Type: "SOURCE"}}},
+			{RoleID: roleSourceReadonlyID, RoleName: roleSourceReadonlyName, Resources: []Resource{{ID: "source_003", Type: resourceTypeSource}}},
 		},
 	}
 	ts.users["user_007"] = User{
@@ -224,7 +248,7 @@ func (ts *TestServer) initSampleData() {
 		Name:  "Grace Wilson",
 		Email: "grace.wilson@example.com",
 		Permissions: []Permission{
-			{RoleID: "role_destination_readonly", RoleName: "Destination Read-only", Resources: []Resource{wsResource}},
+			{RoleID: roleDestReadonlyID, RoleName: roleDestReadonlyName, Resources: []Resource{wsResource}},
 		},
 	}
 
@@ -233,37 +257,37 @@ func (ts *TestServer) initSampleData() {
 		ID:          "group_001",
 		Name:        "Engineering",
 		MemberCount: 4,
-		Members:     []string{"user_001", "user_002", "user_005", "user_006"},
+		Members:     []string{user001ID, user002ID, user005ID, user006ID},
 		Permissions: []Permission{
-			{RoleID: "role_source_admin", RoleName: "Source Admin", Resources: []Resource{{ID: "source_001", Type: "SOURCE"}}},
-			{RoleID: "role_destination_admin", RoleName: "Destination Admin", Resources: []Resource{wsResource}},
+			{RoleID: roleSourceAdminID, RoleName: roleSourceAdminName, Resources: []Resource{{ID: source001ID, Type: resourceTypeSource}}},
+			{RoleID: roleDestAdminID, RoleName: roleDestAdminName, Resources: []Resource{wsResource}},
 		},
 	}
 	ts.groups["group_002"] = Group{
 		ID:          "group_002",
 		Name:        "Data Science",
 		MemberCount: 3,
-		Members:     []string{"user_003", "user_004", "user_005"},
+		Members:     []string{"user_003", "user_004", user005ID},
 		Permissions: []Permission{
-			{RoleID: "role_warehouse_admin", RoleName: "Warehouse Admin", Resources: []Resource{{ID: "warehouse_001", Type: "WAREHOUSE"}}},
+			{RoleID: roleWarehouseAdminID, RoleName: roleWarehouseAdminName, Resources: []Resource{{ID: warehouse001ID, Type: "WAREHOUSE"}}},
 		},
 	}
 	ts.groups["group_003"] = Group{
 		ID:          "group_003",
 		Name:        "Marketing",
 		MemberCount: 2,
-		Members:     []string{"user_006", "user_007"},
+		Members:     []string{user006ID, "user_007"},
 		Permissions: []Permission{
-			{RoleID: "role_source_readonly", RoleName: "Source Read-only", Resources: []Resource{{ID: "source_002", Type: "SOURCE"}}},
+			{RoleID: roleSourceReadonlyID, RoleName: roleSourceReadonlyName, Resources: []Resource{{ID: source002ID, Type: resourceTypeSource}}},
 		},
 	}
 	ts.groups["group_004"] = Group{
 		ID:          "group_004",
 		Name:        "Administrators",
 		MemberCount: 2,
-		Members:     []string{"user_001", "user_002"},
+		Members:     []string{user001ID, user002ID},
 		Permissions: []Permission{
-			{RoleID: "role_workspace_admin", RoleName: "Workspace Admin", Resources: []Resource{wsResource}},
+			{RoleID: roleWorkspaceAdminID, RoleName: roleWorkspaceAdminName, Resources: []Resource{wsResource}},
 		},
 	}
 
@@ -274,38 +298,38 @@ func (ts *TestServer) initSampleData() {
 
 	// Workspace (single workspace per token)
 	ts.workspace = Workspace{
-		ID:   "workspace_001",
+		ID:   workspace001ID,
 		Name: "Test Workspace",
 		Slug: "test-workspace",
 	}
 
 	// Sample sources
-	ts.sources["source_001"] = Source{
-		ID:          "source_001",
+	ts.sources[source001ID] = Source{
+		ID:          source001ID,
 		Slug:        "javascript-source",
 		Name:        "JavaScript Source",
-		WorkspaceID: "workspace_001",
+		WorkspaceID: workspace001ID,
 		Enabled:     true,
 	}
-	ts.sources["source_002"] = Source{
-		ID:          "source_002",
+	ts.sources[source002ID] = Source{
+		ID:          source002ID,
 		Slug:        "python-source",
 		Name:        "Python Source",
-		WorkspaceID: "workspace_001",
+		WorkspaceID: workspace001ID,
 		Enabled:     true,
 	}
 	ts.sources["source_003"] = Source{
 		ID:          "source_003",
 		Slug:        "ios-source",
 		Name:        "iOS Source",
-		WorkspaceID: "workspace_001",
+		WorkspaceID: workspace001ID,
 		Enabled:     false,
 	}
 
 	// Sample warehouses
-	ts.warehouses["warehouse_001"] = Warehouse{
-		ID:          "warehouse_001",
-		WorkspaceID: "workspace_001",
+	ts.warehouses[warehouse001ID] = Warehouse{
+		ID:          warehouse001ID,
+		WorkspaceID: workspace001ID,
 		Enabled:     true,
 		Metadata: &WarehouseMetadata{
 			ID:          "bigquery",
@@ -316,7 +340,7 @@ func (ts *TestServer) initSampleData() {
 	}
 	ts.warehouses["warehouse_002"] = Warehouse{
 		ID:          "warehouse_002",
-		WorkspaceID: "workspace_001",
+		WorkspaceID: workspace001ID,
 		Enabled:     true,
 		Metadata: &WarehouseMetadata{
 			ID:          "snowflake",
@@ -329,14 +353,14 @@ func (ts *TestServer) initSampleData() {
 	// Sample functions
 	ts.functions["func_001"] = Function{
 		ID:           "func_001",
-		WorkspaceID:  "workspace_001",
+		WorkspaceID:  workspace001ID,
 		DisplayName:  "Data Transform Function",
 		Description:  "Transforms incoming data before sending to destinations",
-		ResourceType: "SOURCE",
+		ResourceType: resourceTypeSource,
 	}
 	ts.functions["func_002"] = Function{
 		ID:           "func_002",
-		WorkspaceID:  "workspace_001",
+		WorkspaceID:  workspace001ID,
 		DisplayName:  "Custom Destination Function",
 		Description:  "Custom destination for internal analytics",
 		ResourceType: "DESTINATION",

--- a/cmd/test-server/handlers.go
+++ b/cmd/test-server/handlers.go
@@ -13,6 +13,14 @@ const (
 	// defaultCursor is the base64-encoded default cursor for first page pagination.
 	// This matches the Segment API behavior.
 	defaultCursor = "MA=="
+
+	dataKey        = "data"
+	paginationKey  = "pagination"
+	statusSuccess  = "SUCCESS"
+	groupNameKey   = "name"
+	memberCountKey = "memberCount"
+	permissionsKey = "permissions"
+	statusKey      = "status"
 )
 
 // Pagination represents pagination information.
@@ -86,9 +94,9 @@ func (ts *TestServer) handleListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"users": pageUsers,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(users),
@@ -115,7 +123,7 @@ func (ts *TestServer) handleGetUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"user": user,
 		},
 	}
@@ -152,7 +160,7 @@ func (ts *TestServer) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
 	delete(ts.users, userID)
 
 	logf("✅ DELETE /users - deleted user: %s", userID)
-	sendJSON(w, map[string]interface{}{"data": map[string]string{"status": "SUCCESS"}})
+	sendJSON(w, map[string]interface{}{dataKey: map[string]string{statusKey: statusSuccess}})
 }
 
 // handleListGroups returns all groups with pagination.
@@ -173,8 +181,8 @@ func (ts *TestServer) handleListGroups(w http.ResponseWriter, r *http.Request) {
 	for _, g := range sortedGroups {
 		groups = append(groups, map[string]interface{}{
 			"id":          g.ID,
-			"name":        g.Name,
-			"memberCount": g.MemberCount,
+			groupNameKey:   g.Name,
+			memberCountKey: g.MemberCount,
 		})
 	}
 
@@ -206,9 +214,9 @@ func (ts *TestServer) handleListGroups(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"userGroups": pageGroups,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(groups),
@@ -236,12 +244,12 @@ func (ts *TestServer) handleGetGroup(w http.ResponseWriter, r *http.Request) {
 
 	// Return group with permissions but without member list
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"userGroup": map[string]interface{}{
 				"id":          group.ID,
-				"name":        group.Name,
-				"memberCount": group.MemberCount,
-				"permissions": group.Permissions,
+				groupNameKey:   group.Name,
+				memberCountKey: group.MemberCount,
+				permissionsKey: group.Permissions,
 			},
 		},
 	}
@@ -294,9 +302,9 @@ func (ts *TestServer) handleListGroupUsers(w http.ResponseWriter, r *http.Reques
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"users": pageUsers,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(users),
@@ -347,11 +355,11 @@ func (ts *TestServer) handleAddUsersToGroup(w http.ResponseWriter, r *http.Reque
 	ts.groups[groupID] = group
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"userGroup": map[string]interface{}{
 				"id":          group.ID,
-				"name":        group.Name,
-				"memberCount": group.MemberCount,
+				groupNameKey:   group.Name,
+				memberCountKey: group.MemberCount,
 			},
 		},
 	}
@@ -395,7 +403,7 @@ func (ts *TestServer) handleRemoveUsersFromGroup(w http.ResponseWriter, r *http.
 	ts.groups[groupID] = group
 
 	logf("✅ DELETE /groups/%s/users - removed users: %v", groupID, emails)
-	sendJSON(w, map[string]interface{}{"data": map[string]string{"status": "SUCCESS"}})
+	sendJSON(w, map[string]interface{}{dataKey: map[string]string{statusKey: statusSuccess}})
 }
 
 // handleListRoles returns all roles.
@@ -411,7 +419,7 @@ func (ts *TestServer) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(roles, func(i, j int) bool { return roles[i].ID < roles[j].ID })
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"roles": roles,
 		},
 	}
@@ -461,9 +469,9 @@ func (ts *TestServer) handleListInvites(w http.ResponseWriter, r *http.Request) 
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"invites": pageInvites,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(invites),
@@ -498,7 +506,7 @@ func (ts *TestServer) handleCreateInvites(w http.ResponseWriter, r *http.Request
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"emails": emails,
 		},
 	}
@@ -527,7 +535,7 @@ func (ts *TestServer) handleDeleteInvites(w http.ResponseWriter, r *http.Request
 	}
 
 	logf("✅ DELETE /invites - deleted invites: %v", emails)
-	sendJSON(w, map[string]interface{}{"data": map[string]string{"status": "SUCCESS"}})
+	sendJSON(w, map[string]interface{}{dataKey: map[string]string{statusKey: statusSuccess}})
 }
 
 // handleGetWorkspace returns the current workspace.
@@ -536,7 +544,7 @@ func (ts *TestServer) handleGetWorkspace(w http.ResponseWriter, r *http.Request)
 	defer ts.mu.RUnlock()
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"workspace": ts.workspace,
 		},
 	}
@@ -579,9 +587,9 @@ func (ts *TestServer) handleListSources(w http.ResponseWriter, r *http.Request) 
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"sources": pageSources,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(sources),
@@ -627,9 +635,9 @@ func (ts *TestServer) handleListWarehouses(w http.ResponseWriter, r *http.Reques
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"warehouses": pageWarehouses,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(warehouses),
@@ -678,9 +686,9 @@ func (ts *TestServer) handleListFunctions(w http.ResponseWriter, r *http.Request
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"functions": pageFunctions,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(functions),
@@ -726,9 +734,9 @@ func (ts *TestServer) handleListSpaces(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
+		dataKey: map[string]interface{}{
 			"spaces": pageSpaces,
-			"pagination": Pagination{
+			paginationKey: Pagination{
 				Current:      currentCursor,
 				Next:         nextCursor,
 				TotalEntries: len(spaces),
@@ -774,8 +782,8 @@ func (ts *TestServer) handleAddUserPermissions(w http.ResponseWriter, r *http.Re
 	ts.users[userID] = user
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
-			"permissions": user.Permissions,
+		dataKey: map[string]interface{}{
+			permissionsKey: user.Permissions,
 		},
 	}
 
@@ -817,8 +825,8 @@ func (ts *TestServer) handleReplaceUserPermissions(w http.ResponseWriter, r *htt
 	ts.users[userID] = user
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
-			"permissions": user.Permissions,
+		dataKey: map[string]interface{}{
+			permissionsKey: user.Permissions,
 		},
 	}
 
@@ -860,8 +868,8 @@ func (ts *TestServer) handleAddGroupPermissions(w http.ResponseWriter, r *http.R
 	ts.groups[groupID] = group
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
-			"permissions": group.Permissions,
+		dataKey: map[string]interface{}{
+			permissionsKey: group.Permissions,
 		},
 	}
 
@@ -903,8 +911,8 @@ func (ts *TestServer) handleReplaceGroupPermissions(w http.ResponseWriter, r *ht
 	ts.groups[groupID] = group
 
 	response := map[string]interface{}{
-		"data": map[string]interface{}{
-			"permissions": group.Permissions,
+		dataKey: map[string]interface{}{
+			permissionsKey: group.Permissions,
 		},
 	}
 

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Health check (no auth required, used by CI to verify server is up)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`)) //nolint:errcheck // health check response write failure is non-critical
+		_, _ = w.Write([]byte(`{"status":"ok"}`)) // health check response write failure is non-critical
 	})
 
 	// Workspace endpoint (exact root only — "GET /" is a subtree pattern so guard against other paths)

--- a/config_schema.json
+++ b/config_schema.json
@@ -103,14 +103,6 @@
           "isRequired": true
         }
       }
-    },
-    {
-      "name": "base-url",
-      "displayName": "Base URL",
-      "description": "Base URL for the Segment API",
-      "stringField": {
-        "defaultValue": "https://api.segmentapis.com"
-      }
     }
   ],
   "displayName": "Twilio Segment",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -117,7 +117,7 @@ For more information, see the [Segment Access Management documentation](https://
              Generated from config_schema.json. Do not edit manually. */}
         Paste your credentials into the relevant fields:
 
-        - **Access Token** (required): Your Segment Personal Access Token
+        - **Access Token** (required): Personal Access Token (PAT) for Segment API authentication
         {/* AUTO-GENERATED:END - config-params */}
       </Step>
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Base URL for the Segment API"),
 		field.WithDefaultValue("https://api.segmentapis.com"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/connector/functions.go
+++ b/pkg/connector/functions.go
@@ -78,11 +78,11 @@ func (b *functionBuilder) List(ctx context.Context, parentResourceID *v2.Resourc
 		}
 
 		profile := map[string]interface{}{
-			"id":            fn.ID,
-			"workspace_id":  fn.WorkspaceID,
-			"display_name":  fn.DisplayName,
-			"description":   fn.Description,
-			"resource_type": fn.ResourceType,
+			"id":                  fn.ID,
+			profileWorkspaceIDKey: fn.WorkspaceID,
+			"display_name":        fn.DisplayName,
+			"description":         fn.Description,
+			"resource_type":       fn.ResourceType,
 		}
 
 		resource, err := rs.NewResource(

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -105,7 +105,7 @@ func snakeifyRoleName(name string) (string, error) {
 	var result strings.Builder
 	for _, r := range slug {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
-			result.WriteRune(r)
+			_, _ = result.WriteRune(r)
 		}
 	}
 

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -20,6 +20,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	profileNameKey        = "name"
+	profileWorkspaceIDKey = "workspace_id"
+)
+
 // errRoleNotFound is returned when a role slug cannot be matched to any existing role.
 var errRoleNotFound = errors.New("role not found")
 

--- a/pkg/connector/sources.go
+++ b/pkg/connector/sources.go
@@ -50,11 +50,11 @@ func (b *sourceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 		}
 
 		profile := map[string]interface{}{
-			"id":           source.ID,
-			"slug":         source.Slug,
-			"name":         source.Name,
-			"workspace_id": source.WorkspaceID,
-			"enabled":      source.Enabled,
+			"id":                  source.ID,
+			"slug":                source.Slug,
+			profileNameKey:        source.Name,
+			profileWorkspaceIDKey: source.WorkspaceID,
+			"enabled":             source.Enabled,
 		}
 
 		resource, err := rs.NewResource(

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -50,9 +50,9 @@ func (b *spaceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 		}
 
 		profile := map[string]interface{}{
-			"id":   space.ID,
-			"name": space.Name,
-			"slug": space.Slug,
+			"id":           space.ID,
+			profileNameKey: space.Name,
+			"slug":         space.Slug,
 		}
 
 		resource, err := rs.NewResource(

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -61,8 +61,8 @@ func (b *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 // userResource creates a v2.Resource from a Segment user.
 func userResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"id":   user.ID,
-		"name": user.Name,
+		"id":           user.ID,
+		profileNameKey: user.Name,
 	}
 
 	userTraitOptions := []rs.UserTraitOption{

--- a/pkg/connector/warehouses.go
+++ b/pkg/connector/warehouses.go
@@ -50,13 +50,13 @@ func (b *warehouseBuilder) List(ctx context.Context, parentResourceID *v2.Resour
 		}
 
 		profile := map[string]interface{}{
-			"id":           warehouse.ID,
-			"workspace_id": warehouse.WorkspaceID,
-			"enabled":      warehouse.Enabled,
+			"id":                  warehouse.ID,
+			profileWorkspaceIDKey: warehouse.WorkspaceID,
+			"enabled":             warehouse.Enabled,
 		}
 		if warehouse.Metadata != nil {
 			profile["slug"] = warehouse.Metadata.Slug
-			profile["name"] = warehouse.Metadata.Name
+			profile[profileNameKey] = warehouse.Metadata.Name
 			profile["description"] = warehouse.Metadata.Description
 		}
 


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-segment/config.go,cmd/baton-segment/main.go,pkg/connector/connector.go,pkg/segment/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-segment --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.