### PR TITLE
docs: apply C1 rebrand to connector.mdx

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Twilio Segment connector"
 og:title: "Set up a Twilio Segment connector"
-description: "ConductorOne provides identity governance and just-in-time provisioning for Twilio Segment. Integrate your Twilio Segment workspace with ConductorOne to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
-og:description: "ConductorOne provides identity governance and just-in-time provisioning for Twilio Segment. Integrate your Twilio Segment workspace with ConductorOne to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
+description: "C1 provides identity governance and just-in-time provisioning for Twilio Segment. Integrate your Twilio Segment workspace with C1 to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
+og:description: "C1 provides identity governance and just-in-time provisioning for Twilio Segment. Integrate your Twilio Segment workspace with C1 to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
 sidebarTitle: "Twilio Segment"
 ---
 
@@ -17,14 +17,14 @@ sidebarTitle: "Twilio Segment"
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Users | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Groups | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Roles | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Invites | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Sources | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Warehouses | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Functions | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Spaces | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
+| Users | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Groups | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Roles | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Invites | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Sources | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Warehouses | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Functions | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Spaces | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
 
 {/* AUTO-GENERATED:END - capabilities */}
 
@@ -57,7 +57,7 @@ To configure the Twilio Segment connector, you need **Workspace Owner** or **Wor
   </Step>
 
   <Step>
-    Give the new token a name, such as "ConductorOne". 
+    Give the new token a name, such as "C1". 
   </Step>
   <Step>
     Assign the token the **Workspace Owner** access level. 
@@ -79,11 +79,11 @@ For more information, see the [Segment Access Management documentation](https://
 
 <Tabs>
   <Tab title="Cloud-hosted">
-    Follow these instructions to use a built-in, no-code connector hosted by ConductorOne.
+    Follow these instructions to use a built-in, no-code connector hosted by C1.
 
     <Steps>
       <Step>
-        In ConductorOne, navigate to **Integrations** > **Connectors** and click **Add connector**.
+        In C1, navigate to **Integrations** > **Connectors** and click **Add connector**.
       </Step>
 
       <Step>
@@ -93,15 +93,15 @@ For more information, see the [Segment Access Management documentation](https://
       <Step>
         Choose how to set up the new Twilio Segment connector:
 
-        - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+        - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
         - Add the connector to a managed app (select from the list of existing managed apps)
         - Create a new managed app
       </Step>
 
       <Step>
-        Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+        Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-        If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+        If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
       </Step>
 
       <Step>
@@ -130,19 +130,19 @@ For more information, see the [Segment Access Management documentation](https://
       </Step>
     </Steps>
 
-    **That's it!** Your Twilio Segment connector is now pulling access data into ConductorOne.
+    **That's it!** Your Twilio Segment connector is now pulling access data into C1.
   </Tab>
 
   <Tab title="Self-hosted">
-    Follow these instructions to use the [Twilio Segment](https://github.com/ConductorOne/baton-segment) connector, hosted and run in your own environment.
+    Follow these instructions to use the [Twilio Segment](https://github.com/conductorone/baton-segment) connector, hosted and run in your own environment.
 
-    When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with ConductorOne, automatically syncing and uploading data at regular intervals. This data is immediately available in the ConductorOne UI for access reviews and access requests.
+    When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with C1, automatically syncing and uploading data at regular intervals. This data is immediately available in the C1 UI for access reviews and access requests.
 
     ### Step 1: Set up a new Twilio Segment connector
 
     <Steps>
       <Step>
-        In ConductorOne, navigate to **Integrations** > **Connectors** > **Add connector**.
+        In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
       </Step>
 
       <Step>
@@ -152,15 +152,15 @@ For more information, see the [Segment Access Management documentation](https://
       <Step>
         Choose how to set up the new Twilio Segment connector:
 
-        - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+        - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
         - Add the connector to a managed app (select from the list of existing managed apps)
         - Create a new managed app
       </Step>
 
       <Step>
-        Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+        Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-        If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+        If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
       </Step>
 
       <Step>
@@ -192,18 +192,18 @@ For more information, see the [Segment Access Management documentation](https://
       name: baton-segment-secrets
     type: Opaque
     stringData:
-      # ConductorOne credentials
-      BATON_CLIENT_ID: <ConductorOne client ID>
-      BATON_CLIENT_SECRET: <ConductorOne client secret>
+      # C1 credentials
+      BATON_CLIENT_ID: <C1 client ID>
+      BATON_CLIENT_SECRET: <C1 client secret>
 
       # Twilio Segment credentials
       BATON_TOKEN: <Your Segment Personal Access Token>
 
-      # Optional: include if you want ConductorOne to provision access using this connector
+      # Optional: include if you want C1 to provision access using this connector
       BATON_PROVISIONING: "true"
     ```
 
-    See the [connector README](https://github.com/ConductorOne/baton-segment) or run `--help` to see all available configuration flags and environment variables.
+    See the [connector README](https://github.com/conductorone/baton-segment) or run `--help` to see all available configuration flags and environment variables.
 
     #### Deployment configuration
 
@@ -242,14 +242,14 @@ For more information, see the [Segment Access Management documentation](https://
 
     <Steps>
       <Step>
-        Create a namespace in which to run ConductorOne connectors (if desired), then apply the secret config and deployment config files.
+        Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
       </Step>
 
       <Step>
-        Check that the connector data uploaded correctly. In ConductorOne, click **Applications**. On the **Managed apps** tab, locate and click the name of the application you added the Twilio Segment connector to. Twilio Segment data should be found on the **Entitlements** and **Accounts** tabs.
+        Check that the connector data uploaded correctly. In C1, click **Applications**. On the **Managed apps** tab, locate and click the name of the application you added the Twilio Segment connector to. Twilio Segment data should be found on the **Entitlements** and **Accounts** tabs.
       </Step>
     </Steps>
 
-    **That's it!** Your Twilio Segment connector is now pulling access data into ConductorOne.
+    **That's it!** Your Twilio Segment connector is now pulling access data into C1.
   </Tab>
 </Tabs>


### PR DESCRIPTION
Updates `docs/connector.mdx` with the C1 rebrand:

- Renames **ConductorOne** → **C1** in prose, comments, and placeholder text
- Updates brand color `#65DE23` → `#c937ae`
- Lowercases GitHub org name in the repository resource link

URLs that are case-sensitive or functional (distro site, tenant URLs, email addresses, file paths) are unchanged.