### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -71,7 +71,7 @@ To configure the Twilio Segment connector, you need **Workspace Owner** or **Wor
     Carefully copy and save the new token.
   </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 For more information, see the [Segment Access Management documentation](https://segment.com/docs/segment-app/iam/).
 
@@ -130,7 +130,7 @@ For more information, see the [Segment Access Management documentation](https://
       </Step>
     </Steps>
 
-    **That's it!** Your Twilio Segment connector is now pulling access data into C1.
+    **Done.** Your Twilio Segment connector is now pulling access data into C1.
   </Tab>
 
   <Tab title="Self-hosted">
@@ -257,6 +257,6 @@ For more information, see the [Segment Access Management documentation](https://
       </Step>
     </Steps>
 
-    **That's it!** Your Twilio Segment connector is now pulling access data into C1.
+    **Done.** Your Twilio Segment connector is now pulling access data into C1.
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.