### PR TITLE
feat: mark invite resource type as skipSyncAnomalyDetection

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -46,6 +46,9 @@
         "annotations": [
           {
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipSyncAnomalyDetection"
           }
         ],
         "description": "A pending workspace invitation"
@@ -55,7 +58,8 @@
         "CAPABILITY_ACCOUNT_PROVISIONING",
         "CAPABILITY_RESOURCE_DELETE"
       ],
-      "permissions": {}
+      "permissions": {},
+      "skipSyncAnomalyDetection": true
     },
     {
       "resourceType": {

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -34,7 +34,7 @@ The Twilio Segment connector supports [automatic account deprovisioning](/docs/p
 **Notes:**
 - Roles are Segment's built-in IAM roles (e.g., Workspace Owner, Source Admin, Function Admin). They are system-defined and cannot be created or deleted.
 - Warehouses and Spaces require a **Business plan** workspace.
-- Invites represent pending workspace invitations. Creating an invite sends an email to the specified address.
+- Invites represent pending workspace invitations. Creating an invite sends an email to the specified address. Invite counts fluctuate as invitations are accepted or expire, so this resource type is excluded from sync anomaly detection.
 - Groups (User Groups) are a **Business plan** feature.
 
 ## Gather Twilio Segment credentials

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -54,7 +54,10 @@ var inviteResourceType = &v2.ResourceType{
 	DisplayName: "Invite",
 	Description: "A pending workspace invitation",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-	Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+	Annotations: annotations.New(
+		&v2.SkipEntitlementsAndGrants{},
+		&v2.SkipSyncAnomalyDetection{},
+	),
 }
 
 // Resource type for data sources.


### PR DESCRIPTION
## Summary
Mark the `invite` resource type with the `SkipSyncAnomalyDetection` annotation. Counts on this type can legitimately drop between syncs as pending invitees accept and are reclassified as users. Without this annotation, sync anomaly detection would flag those expected drops.

The `user` resource type intentionally remains anomaly-checked.

## Test plan
- [x] `go build ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
