### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/functions.go
+++ b/pkg/connector/functions.go
@@ -90,9 +90,8 @@ func (b *functionBuilder) List(ctx context.Context, parentResourceID *v2.Resourc
 			functionResourceType,
 			fn.ID,
 			rs.WithParentResourceID(parentResourceID),
-			rs.WithAppTrait(
-				rs.WithAppProfile(profile),
-			),
+			rs.WithAppTrait(),
+			rs.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, &rs.SyncOpResults{Annotations: outputAnnotations}, fmt.Errorf("failed to create function resource: %w", err)

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -93,15 +93,14 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId) (*v2.Re
 		"member_count": group.MemberCount,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	return rs.NewGroupResource(
 		group.Name,
 		groupResourceType,
 		group.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/session"
@@ -18,6 +16,8 @@ import (
 	"github.com/conductorone/baton-segment/pkg/connector/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (

--- a/pkg/connector/invites.go
+++ b/pkg/connector/invites.go
@@ -63,7 +63,6 @@ func inviteResource(email string, parentResourceID *v2.ResourceId) (*v2.Resource
 	userTraitOptions := []rs.UserTraitOption{
 		rs.WithEmail(email, true),
 		rs.WithUserLogin(email),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_DISABLED), // Disabled status until accepted
 	}
 
 	// Add "(Invitation)" prefix to make it clear this is a pending invite, not an active user
@@ -75,6 +74,7 @@ func inviteResource(email string, parentResourceID *v2.ResourceId) (*v2.Resource
 		inviteResourceType,
 		email, // Use email as ID
 		userTraitOptions,
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, ""), // Disabled until accepted
 		rs.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -55,15 +55,14 @@ func roleResource(role *client.Role, parentResourceID *v2.ResourceId) (*v2.Resou
 		"id": role.ID,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []rs.RoleTraitOption{}
 
 	return rs.NewRoleResource(
 		role.Name,
 		roleResourceType,
 		role.ID,
 		roleTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 		rs.WithDescription(role.Description),
 	)

--- a/pkg/connector/sources.go
+++ b/pkg/connector/sources.go
@@ -62,9 +62,8 @@ func (b *sourceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 			sourceResourceType,
 			source.ID,
 			rs.WithParentResourceID(parentResourceID),
-			rs.WithAppTrait(
-				rs.WithAppProfile(profile),
-			),
+			rs.WithAppTrait(),
+			rs.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, &rs.SyncOpResults{Annotations: outputAnnotations}, fmt.Errorf("failed to create source resource: %w", err)

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -60,9 +60,8 @@ func (b *spaceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 			spaceResourceType,
 			space.ID,
 			rs.WithParentResourceID(parentResourceID),
-			rs.WithAppTrait(
-				rs.WithAppProfile(profile),
-			),
+			rs.WithAppTrait(),
+			rs.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, &rs.SyncOpResults{Annotations: outputAnnotations}, fmt.Errorf("failed to create space resource: %w", err)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -67,8 +67,6 @@ func userResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resou
 
 	userTraitOptions := []rs.UserTraitOption{
 		rs.WithEmail(user.Email, true),
-		rs.WithUserProfile(profile),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED), // Segment users are always enabled (deleted if inactive)
 	}
 
 	if user.Email != "" {
@@ -85,6 +83,8 @@ func userResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resou
 		userResourceType,
 		user.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""), // Segment users are always enabled (deleted if inactive)
 		rs.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/warehouses.go
+++ b/pkg/connector/warehouses.go
@@ -65,9 +65,8 @@ func (b *warehouseBuilder) List(ctx context.Context, parentResourceID *v2.Resour
 			warehouseResourceType,
 			warehouse.ID,
 			rs.WithParentResourceID(parentResourceID),
-			rs.WithAppTrait(
-				rs.WithAppProfile(profile),
-			),
+			rs.WithAppTrait(),
+			rs.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, &rs.SyncOpResults{Annotations: outputAnnotations}, fmt.Errorf("failed to create warehouse resource: %w", err)


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is currently red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource
- hand-built `UserTrait{Profile, Status}` -> the `Profile` / `Status` fields on `Resource`

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.